### PR TITLE
Disable proximity meeting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,11 @@ let currentPopup: any = undefined;
 // Waiting for the API to be ready
 WA.onInit().then(() => {
     console.log('Scripting API ready');
-    console.log('Player tags: ',WA.player.tags)
+    console.log('Player tags: ',WA.player.tags);
+
+    // Disable proximity meeting
+    // DELETE ME if you want to enable proximity meeting for your future events
+    WA.controls.disablePlayerProximityMeeting();
 
     WA.room.area.onEnter('clock').subscribe(() => {
         const today = new Date();


### PR DESCRIPTION
There is an issue with the SILENT zone when user spawn. To fix it for the SHAKA Biarritz event, we need to disable proximity meeting.

After the event, remove this change to enable proximity meeting.